### PR TITLE
Save all artifacts used

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: app.bin
-        path: espressif/build/switchbota.bin
+        path: |
+          espressif/build/bootloader/bootloader.bin
+          espressif/build/partition_table/partition-table.bin
+          espressif/build/switchbota.bin


### PR DESCRIPTION
After these artifacts are exported, I can successfully build (with manual flashing, unsure if it works with an out of box SwitchBot yet. Also, you need an AP with SSID:switchbota/PW:switchbota set up):
```
$ python3 ~/git/esptool/esptool.py -b 460800 --before default_reset --after hard_reset --chip esp32c3 erase_flash
$ python3 ~/git/esptool/esptool.py -b 460800 --before default_reset --after hard_reset --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 bootloader/bootloader.bin 0x8000 partition_table/partition-table.bin 0x20000 switchbota.bin
```
It may work with more or less flags (I started with what esp-idf compile output gave me), but these exact flags got me working with Tasmota successfully.
Also, using `arendst/Tasmota/releases/download/v11.1.0/tasmota32c3.factory.bin` got me able to successfully OTA flash upgrade! (To the same version, but, proof of concept worked.) Also, it shows 4MB in the Tasmota interface now!

Tasmota Information now reads:
![image](https://user-images.githubusercontent.com/636551/169782492-2c25c701-529d-419b-872c-d1eff842e1af.png)
