### PR TITLE
server docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm" # will create PR for package updates when it identifies new versions
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: version
     steps:
+    - uses: actions/checkout@v3
     - name: Prepare
       id: prep
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: esp-idf build
@@ -22,3 +22,62 @@ jobs:
       with:
         name: app.bin
         path: espressif/build/switchbota.bin
+  version: # this is to create the version for docker image
+    runs-on: ubuntu-latest
+    outputs:
+      app_version: ${{ steps.semvers.outputs.patch }} # set the app_version to be the PATCH updated version
+      tag: ${{ steps.semvers.outputs.v_patch }} # set the tag to be the PATCH updated version.
+    env:
+      GITHUB_TOKEN: "${{ github.token }}"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    # Get the current tag
+    - name: 'Get Previous tag'
+      id: previoustag
+      uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      with:
+        fallback: 1.1.0 # Optional fallback tag to use when no tag can be found
+    # calculate the next version
+    - name: 'Get next minor version'
+      id: semvers
+      uses: "WyriHaximus/github-action-next-semvers@v1"
+      with:
+        version: ${{ steps.previoustag.outputs.tag }}
+    - run: echo "app_version ${{ steps.semvers.outputs.patch }}"
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: version
+    steps:
+    - name: Prepare
+      id: prep
+      run: |
+        GHCR_IMAGE="ghcr.io/${{ github.repository }}/switchbota-server";
+
+        TAGS="${GHCR_IMAGE}:latest,${GHCR_IMAGE}:${{ needs.version.outputs.app_version }}";
+        echo ::set-output name=tags::${TAGS}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+         # this will use the user that is running the action. and will fail if they dont have permission
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build and Push GHCR
+      id: docker_build
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        build-args: |
+          PROJECT_NAME=switchbota-server
+          BUILD_VERSION=${{ needs.version.outputs.app_version }}
+        tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v3
       with:
+        context: ./server
         push: true
         build-args: |
           PROJECT_NAME=switchbota-server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,3 +84,9 @@ jobs:
           PROJECT_NAME=switchbota-server
           BUILD_VERSION=${{ needs.version.outputs.app_version }}
         tags: ${{ steps.prep.outputs.tags }}
+    - name: Create Tag
+      uses: negz/create-tag@v1
+      with:
+        version: ${{ needs.version.outputs.tag }}
+        message: ''
+        token: ${{ github.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: SwitchbOTA app.bin build
 on: push
 
 jobs:
-  build:
+  firmware-build:
   
     runs-on: ubuntu-latest
 
@@ -44,6 +44,7 @@ jobs:
       id: semvers
       uses: "WyriHaximus/github-action-next-semvers@v1"
       with:
+        strict: false
         version: ${{ steps.previoustag.outputs.tag }}
     - run: echo "app_version ${{ steps.semvers.outputs.patch }}"
   docker-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v3
       with:
-        context: ./server/Dockerfile
+        context: "${{ github.workspace }}/server/"
         push: true
         build-args: |
           PROJECT_NAME=switchbota-server

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v3
       with:
-        context: ./server
+        context: ./server/Dockerfile
         push: true
         build-args: |
           PROJECT_NAME=switchbota-server

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,3 @@
+docker-compose-nginx.yml
+docker-compose.yml
+Dockerfile

--- a/server/.npmignore
+++ b/server/.npmignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+docker-compose-nginx.yml
+docker-compose.yml

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,4 +13,6 @@ RUN \
 
 WORKDIR /app
 
+EXPOSE 80
+
 ENTRYPOINT "node" "/app/index.js"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:current-alpine
+# set via build
+ARG PROJECT_NAME="switchbota-server"
+ARG BUILD_VERSION="1.0.0-snapshot"
+
+COPY . /app
+
+RUN \
+  apk update && \
+  rm -rf /var/cache/apk/* && \
+  cd /app && \
+  npm install
+
+WORKDIR /app
+
+ENTRYPOINT "node" "/app/index.js"

--- a/server/README.md
+++ b/server/README.md
@@ -17,3 +17,50 @@ node index.js 192.168.1.105
 ```
 
 Where _192.168.1.105_ is the IP address of the system running the Node application. Then, in your router's DHCP settings, configure the default DNS server to similarly be _192.168.1.105_, or whatever IP is used before. Almost all routers allow you to configure the default DNS server via their configuration portals - please see the manual for yours for specific instructions.
+
+
+## Docker
+
+### Docker Compose
+
+There are 2 docker compose files. One uses host networking, with port `80` exposed. 
+
+The other uses `2180` and is meant to be used in conjunction with nginx (or some other reverse proxy). 
+See [How to configure a docker nginx reverse proxy](https://www.theserverside.com/blog/Coffee-Talk-Java-News-Stories-and-Opinions/Docker-Nginx-reverse-proxy-setup-example) for help and example on how to do this.
+#### SAMPLE NGINX CONFIG
+```
+upstream switchbota_app {
+	server 192.168.1.123:2180;
+}
+
+server {
+	listen 80 default_server;
+	server_name _;
+
+	location / {
+		resolver 192.168.1.3;
+
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+		proxy_pass http://switchbota_app;
+	}
+}
+```
+
+### Docker Run
+```
+docker run --rm -p 80:80 ghcr.io/kendallgoto/switchbota/switchbota-server:latest
+```
+
+## Docker with Integrated DNS Server
+
+Just like starting the server with node, you can pass the IP Address of the host 
+
+```
+docker run --rm --network=host ghcr.io/kendallgoto/switchbota/switchbota-server:latest 192.168.1.105
+```
+
+### Docker Compose
+If you use the docker-compose you can uncomment the `command:` value and set that to the IP Address.

--- a/server/README.md
+++ b/server/README.md
@@ -29,20 +29,25 @@ The other uses `2180` and is meant to be used in conjunction with nginx (or some
 See [How to configure a docker nginx reverse proxy](https://www.theserverside.com/blog/Coffee-Talk-Java-News-Stories-and-Opinions/Docker-Nginx-reverse-proxy-setup-example) for help and example on how to do this.
 #### SAMPLE NGINX CONFIG
 ```
+
 upstream switchbota_app {
-	server 192.168.1.123:2180;
+  server 192.168.1.123:2180;
 }
 
 server {
-	listen 80 default_server;
-	server_name _;
-
+	listen 80;
+	server_name wohand.com 
+	server_name www.wohand.com 
+	server_name a.wohand.com; # wohand.com original DNS is set to CNAME a.wohand.com
 	location / {
-		resolver 192.168.1.3;
+		resolver 192.168.1.1; # Your DNS
 
+		proxy_http_version  1.1;
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
 
 		proxy_pass http://switchbota_app;
 	}

--- a/server/docker-compose-nginx.yml
+++ b/server/docker-compose-nginx.yml
@@ -6,6 +6,8 @@ services:
     container_name: switchbota
     image: ghcr.io/kendallgoto/switchbota/switchbota-server:latest
     network_mode: "bridge"
+    # uncomment and change the ip to use integrated DNS
+    # command: 192.168.1.105
     ports:
     - 80:2180
     environment: []

--- a/server/docker-compose-nginx.yml
+++ b/server/docker-compose-nginx.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+services:
+   switchbota:
+    user: 1000:1000
+    hostname: switchbota
+    container_name: switchbota
+    image: ghcr.io/kendallgoto/switchbota/switchbota-server:latest
+    network_mode: "bridge"
+    ports:
+    - 80:2180
+    environment: []
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 64M
+        reservations:
+          cpus: '0.25'
+          memory: 32M

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+services:
+   switchbota:
+    user: 1000:1000
+    hostname: switchbota
+    container_name: switchbota
+    image: ghcr.io/kendallgoto/switchbota/switchbota-server:latest
+    network_mode: "host"
+    ports:
+    - 80:80
+    environment: []
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 64M
+        reservations:
+          cpus: '0.25'
+          memory: 32M

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: switchbota
     image: ghcr.io/kendallgoto/switchbota/switchbota-server:latest
     network_mode: "host"
+    # uncomment and change the ip to use integrated DNS
+    # command: 192.168.1.105
     ports:
     - 80:80
     environment: []


### PR DESCRIPTION
Provides a docker image, that is published to the repo's GHCR packages.

- Updated the github action to build the image
- renamed the `build` to `firmware-build`
- updated the checkout action to version 3
- creates a semantic version x.x.x to tag the image with
  - creates the tag in the git tags as well
- added 2 sample docker compose files 
  - run as host network mode
  - run in bridge network mode for use behind a reverse proxy like nginx
- updated the readme to include info on the docker image
- added dependabot config to monitor npm packages
