### PR TITLE
Update README with new firmware info

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Some details about the devices are as follows:
 - They are ultrasonically welded shut, requiring destruction of the plastic housing to access the circuits within. There are no screws to allow access to the internals, the way there is with the Sonoff S31
 - They use the Shanghai Belling BL0937 energy measurement IC to track power usage
 - They use the Espressif ESP32-C3 chip for WiFi, Bluetooth Low Energy (BLE), and circuit control. See [here](https://tasmota.github.io/docs/ESP32/#esp32-differences) to learn about the different types of ESP32. The MAC addresses for WiFi and BLE follow the [ESP32 standard](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/system/misc_system_api.html#mac-address) of having an offset of two. If the WIFI-MAC is `34:85:18:0F:CC:DC`, then the BLE-MAC is `34:85:18:0F:CC:DE` (DC in hex is 220, DE is 222)
-- The SwitchbOTA flashing process is confirmed to work on both device models using firmware v1.4 or older (v1.3, v1.2)
+- The SwitchbOTA flashing process is confirmed to work on both device models using firmware v1.8 or older (v1.5, v1.4, v1.3, v1.2)
 
 ## Disclaimer
 Writing to the bootloader over OTA is dangerous and not normally done for good reason. If your device loses power or somehow flashes corrupted data, the device will be bricked and require disassembly to reprogram the device. Only perform this process if you are comfortable disassembling your plug to fix it if it breaks! Of course, do not unplug or otherwise disturb the plug while it is performing the OTA.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This project helps to replace the default firmware on the SwitchBot Smart Plug M
 
 There are two SKUs of the SwitchBot Smart Plug Mini released in the US: 
 
-- The original "Smart Plug Mini" with model number W1901400, released in early 2022. As of 2023-12, Amazon sells these in [four-packs](https://www.amazon.com/dp/B09YV2L3MN) for about $30, [two-packs](https://www.amazon.com/dp/B09YV3LH8Y) for $19, or [one-packs](https://www.amazon.com/dp/B09QFLJH8T) for $12
-- The updated "HomeKit Smart Plug Mini" with model number W1901401, released later in 2022. As of 2023-12, Amazon sells these in [four-packs](https://www.amazon.com/dp/B0B9RHTM6Y) for about $38 or [one-packs](https://www.amazon.com/dp/B0B39DJFR8) for $15
+- The original "Smart Plug Mini" with model number W1901400, released in early 2022. As of 2023-12, Amazon sells these in [four-packs](https://www.amazon.com/dp/B0DSJHFG69) for about $30, [two-packs](https://www.amazon.com/dp/B0DSJF58LT) for $19, or [one-packs](https://www.amazon.com/dp/B0DSJK8B73) for $12
+- The updated "HomeKit Smart Plug Mini" with model number W1901401, released later in 2022. As of 2023-12, Amazon sells these in [four-packs](https://www.amazon.com/dp/B0DSJGH1VP) for about $38, [two-packs](https://www.amazon.com/dp/B0DSJGGHDF) for $25, or [one-packs](https://www.amazon.com/dp/B0DSJH7YG6) for $15
 
 Some details about the devices are as follows:
 


### PR DESCRIPTION
I'm back! I just bought four of the "2025 New" SwitchBot Plug Minis. Still the exact same hardware, and even the model number hasn't changed, it's still W1901400. I guess they just wanted to make a new ASIN and product listing on Amazon, bizarre https://www.amazon.com/gp/product/B0DSJHFG69 is the new listing.

Anyway, I just opened the box and got them flashed using SwitchbOTA, no issues. The app showed a pending firmware update from the installed version v1.8 up to v2.7, so I got the NodeJS server up and running and it still worked perfectly:


```
root@debian-test-vm:~/switchbota/server# node index.js
Server listening on port 80
::ffff:192.168.1.3 - /
::ffff:192.168.1.200 - /version/wocaotech/firmware/WoPlugUS/WoPlugUS_V27.bin
::ffff:192.168.1.200 - /payload.bin
::ffff:192.168.1.201 - /version/wocaotech/firmware/WoPlugUS/WoPlugUS_V27.bin
::ffff:192.168.1.201 - /payload.bin
::ffff:192.168.1.202 - /version/wocaotech/firmware/WoPlugUS/WoPlugUS_V27.bin
::ffff:192.168.1.202 - /payload.bin
```

Anyway, I updated the README to note that it should still work with firmware v1.8 👍 

I'm also happy to see that this project is still the defacto standard for flashing these, and is even referenced by another ESPHome-specific project https://github.com/taikun114/SwitchBot-Plug-Mini-for-ESPHome